### PR TITLE
Adding support for intel drm graphics drivers and misc

### DIFF
--- a/states/automount/init.sls
+++ b/states/automount/init.sls
@@ -1,12 +1,6 @@
-automount:
-  service.running:
-    - reload: False
-
 automountd:
   service.running:
     - reload: False
-    - watch:
-        - service: automount
 
 autounmountd:
   service.running:
@@ -30,7 +24,7 @@ autounmountd:
     - require:
         - file: /mnt/nfs
     - watch_in:
-        - service: automount
+        - service: automountd
 
 /etc/auto_nfs:
   file.managed:
@@ -44,4 +38,4 @@ autounmountd:
     - require:
         - file: /etc/auto_master
     - watch_in:
-        - service: automount
+        - service: automountd

--- a/states/automount/init.sls
+++ b/states/automount/init.sls
@@ -31,7 +31,7 @@ autounmountd:
     - source: salt://{{ tpldir }}/auto_nfs.jinja
     - template: jinja
     - context:
-        mountpoints: {{ salt['pillar.get']('nfs_mountpoints', {}) }}
+        mountpoints: {{ salt['pillar.get']('nfs_mountpoints', {}) | json_decode_dict }}
     - user: root
     - group: wheel
     - mode: 644

--- a/states/desktop_pkgs.sls
+++ b/states/desktop_pkgs.sls
@@ -37,15 +37,8 @@ desktop_pkgs:
       - zathura
       - zathura-pdf-poppler
       - xrandr
-      # Term session recording
       - xwd # Wont need after bug fix
-      - ttygif
-      - ttyrec
       - exfat-utils
-      # mail client
-      - claws-mail
-      - claws-mail-fancy
-      - claws-mail-archiver
       - en-hunspell
       - newsboat
       # Fonts
@@ -74,6 +67,13 @@ removed_desktop_pkgs:
       - newsbeuter  # Moving to newsboat
       - xpdf  # xpdf 4.x requires qt5, staying on xpdf3
       - xpdf3 # Found a better alternative in zathura
+      # moving away from claws-mail client
+      - claws-mail
+      - claws-mail-fancy
+      - claws-mail-archiver
+      # remove Term session recording
+      - ttygif
+      - ttyrec
     - require:
       - sls: pkgng
 

--- a/states/desktop_pkgs.sls
+++ b/states/desktop_pkgs.sls
@@ -30,7 +30,7 @@ desktop_pkgs:
       # Image viewer
       - viewnior
       # Picture stuff
-      - ImageMagick
+      - ImageMagick7
       - darktable
       - ufraw
       # PDF Viewer

--- a/states/intel/init.sls
+++ b/states/intel/init.sls
@@ -1,0 +1,8 @@
+drm-kmod:
+  pkg.installed: []
+
+kld_list:
+  sysrc.managed:
+    - value: "/boot/modules/i915kms.ko"
+    - require:
+      - pkg: drm-kmod

--- a/states/pkgng/conf/pkg.conf.jinja
+++ b/states/pkgng/conf/pkg.conf.jinja
@@ -2,9 +2,9 @@
   url: "{{ url }}"
   mirror_type: "{{ mirror_type }}",
   signature_type: "{{ signature_type }}",
-  {% if signature_type == "pubkey" %}
+  {% if signature_type == "pubkey" -%}
   pubkey: "{{ pubkey }}",
-  {% endif %}
+  {% endif -%}
   fingerprints: "{{ fingerprints }}",
   enabled: {{ enabled }},
   priority: {{ priority }}

--- a/states/salt/init.sls
+++ b/states/salt/init.sls
@@ -15,8 +15,6 @@ py27-salt:
   file.managed:
     - contents: |
         file_client: local
-        jinja_trim_blocks: True
-        jinja_lstrip_blocks: True
     - user: root
     - group: wheel
     - mode: 644

--- a/states/top.sls
+++ b/states/top.sls
@@ -29,7 +29,6 @@ base:
     - intel
     - users.desktop
     - gnupg
-    - iohyve
     - ruby
     - golang
     - google.kube

--- a/states/top.sls
+++ b/states/top.sls
@@ -17,6 +17,7 @@ base:
     - zfsnap
     - dsbmd
   'robs-desktop':
+    - intel
     - users.desktop
     - gnupg
     - ruby
@@ -25,6 +26,7 @@ base:
     - google.sdk
     - iohyve
   'robs-laptop':
+    - intel
     - users.desktop
     - gnupg
     - iohyve


### PR DESCRIPTION
## Description

Adding new drm drivers for intel graphics. Fixing all other lingering issue around `salt-call state.highstate`

## Testing

Currently highstate is working as intended:

```
Summary for local
-------------
Succeeded: 75 (changed=3)
Failed:     0
-------------
Total states run:     75
Total run time:   18.783 s
```